### PR TITLE
#154商品新規登録に関する修正等

### DIFF
--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -1,47 +1,43 @@
 <div class="col-md-6 col-md-offset-3">
   <%= form_with(model: item, url: items_path, method: :post, local: true) do |form| %>
     <div class="field">
-      <%= form.label :item_title %>
+      <%= form.label :商品タイトル %>
       <%= form.text_field :item_title, class:"form-control" %>
     </div>
 
     <div class="field">
-      <%= form.label :part_number %>
+      <%= form.label :製品コード%>
       <%= form.text_field :part_number, class:"form-control" %>
     </div>
 
     <div class="field">
-      <%= form.label :simulate_price %>
+      <%= form.label :想定金額 %>
       <%= form.text_field :simulate_price, class:"form-control" %>
     </div>
 
-    <div class="field">
-      <%= form.label :item_picture %>
-      <%= form.text_field :item_picture, class:"form-control" %>
-    </div>
     <%= form.fields_for :stocks do |stock| %>
       <div class="field">
-        <%= stock.label :buy_item_to_jpy %>
+        <%= stock.label :仕入原価（日本円） %>
         <%= stock.number_field :buy_item_to_jpy, class:"form-control" %>
       </div>
 
       <div class="field">
-        <%= stock.label :buy_item_title %>
+        <%= stock.label :仕入タイトル %>
         <%= stock.text_field :buy_item_title, class:"form-control" %>
       </div>
 
       <div class="field">
-        <%= stock.label :buy_item_url %>
+        <%= stock.label :仕入リンク %>
         <%= stock.text_field :buy_item_url, class:"form-control" %>
       </div>
 
       <div class="field">
-        <%= stock.label :buy_item_to_cny %>
+        <%= stock.label :仕入原価（中国元） %>
         <%= stock.number_field :buy_item_to_cny, class:"form-control" %>
       </div>
 
       <div class="field">
-        <%= stock.label :buy_item_image_url %>
+        <%= stock.label :仕入画像リンク %>
         <%= stock.text_field :buy_item_image_url, class:"form-control" %>
       </div>
       <% end %>

--- a/app/views/items/product_scarce.html.erb
+++ b/app/views/items/product_scarce.html.erb
@@ -55,13 +55,13 @@ function show_hide_row(row) {
   <% k=i%2 %>
   <tr class="tr-back<%= k %>">
     <td align="center" style="padding: 2px;" onclick="show_hide_row('hidden_row<%=i %>')" ;>
-      <% if item.item_picture.present? %>
-        <% uri=URI.parse(item.item_picture) %>
-      <% end %>
-      <% if uri.scheme=="https" or uri.scheme=="http" %>
-        <%= image_tag item.item_picture, :size =>'50x25' %>
-      <% end %>
-    </td>
+        <% if item.item_picture.present? %>
+          <% uri=URI.parse(item.item_picture) %>
+          <% if uri.scheme=="https" or uri.scheme=="http" %>
+            <%= image_tag item.item_picture, :size =>'60x45' %>
+          <% end %>
+        <% end %>
+      </td>
     <td align="center" style="padding: 2px;">
       <%= form_with(url: items_item_number_path, method: :post, local: true) do |form| %>
         <%= form.text_field :part_number, value: item.part_number,style:"width: 100px;" %>

--- a/app/views/items/sold_out.html.erb
+++ b/app/views/items/sold_out.html.erb
@@ -60,9 +60,9 @@ function show_hide_row(row) {
     <td align="center" style="padding: 2px;" onclick="show_hide_row('hidden_row<%=i %>')" ;>
       <% if item.item_picture.present? %>
         <% uri=URI.parse(item.item_picture) %>
-      <% end %>
-      <% if uri.scheme=="https" or uri.scheme=="http" %>
-        <%= image_tag item.item_picture, :size =>'50x25' %>
+        <% if uri.scheme=="https" or uri.scheme=="http" %>
+          <%= image_tag item.item_picture, :size =>'60x45' %>
+        <% end %>
       <% end %>
     </td>
     <td align="center" style="padding: 2px;" align="center">

--- a/app/views/stocks/inventory_control.html.erb
+++ b/app/views/stocks/inventory_control.html.erb
@@ -137,11 +137,11 @@
           <% yahooshoping=item.yahooshoping %>
           <% k=i%2 %>
           <tr class="tr-back<%= k %>">
-            <td onclick="show_hide_row('hidden_row<%=i %>')" ;>
+            <td style="padding:2px"; onclick="show_hide_row('hidden_row<%=i %>')" ;>
               <% if item.item_picture.present? %>
                 <% uri=URI.parse(item.item_picture) %>
                 <% if uri.scheme=="https" or uri.scheme=="http" %>
-                  <%= image_tag item.item_picture, :size =>'50x25' %>
+                  <%= image_tag item.item_picture, :size =>'60x45' %>
                 <% end %>
               <% end %>
             </td>
@@ -240,13 +240,13 @@
                 <% if stocklist.item.item_picture.present? %>
                   <% uri=URI.parse(stocklist.item.item_picture) %>
                   <% if uri.scheme=="https" or uri.scheme=="http" %>
-                    <%= image_tag stocklist.item.item_picture, :size =>'50x25' %>
+                    <%= image_tag stocklist.item.item_picture, :size =>'60x45' %>
                   <% end %>
                 <% end %>
               </td>
               <td><%= stocklist.item.part_number %></td>
-              <td><%= stocklist.item.item_title[0,30] %></td>
-              <td><%= stocklist.trader_name[0,8] %></td>
+              <td><%= stocklist.item.item_title %></td>
+              <td><%= stocklist.trader_name %></td>
               <td align="right"><%= stocklist.stock %></td>
               <td align="right"><%= stocklist.purchase_price.to_s(:delimited, delimiter: ',') if stocklist.purchase_price.present? %></td>
               <td align="center"><%= buy.text_field:japan_description %></td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,18 +7,6 @@ User.create!(name: "Sample User",
              password_confirmation: "password",
              address: "神奈川県横浜市戸塚区俣野町1403",
              phone_number: "080-1234-1234",
+             inventory_manager_flg: true,
+             reserch_user_flg: true,
              admin: 1)
-10.times do |n|
-  name = Faker::Name.name
-  email = "test-#{n+1}@email.com"
-  password = "password"
-  address = "神奈川県横浜市戸塚区俣野町#{n+1}"
-  phone_number = "080-1234-1234#{n+1}"
-  User.create!(name: name,
-               line_id: "123456789",
-               email: email,
-               password: password,
-               password_confirmation: password,
-               address: address,
-               phone_number: phone_number)
-end


### PR DESCRIPTION
商品新規登録の画面、項目を日本語に修正
登録時、表示一覧表にエラーがでたため、ビュー画面修正
商品一覧表の仕入一括登録、文字制限廃止
一覧表の写真表示のサイズ変更（６０✖️４５にした）