### PR TITLE
#165_商品登録遷移の画像の位置を修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -410,8 +410,9 @@ a.btn.btn-success.btn-lg {
 }
 
 .reserch_btn{
-  position: fixed;
+  //position: fixed; 画像右下に常時表示・・・PC環境によって誤作動
   float: right;
+  margin-top: 60px;
   right: 50px;
   bottom: 100px;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -102,13 +102,3 @@
     </nav>
   </div>
 </header>
-<% if logged_in? && current_user.admin? %>
-  <div class="reserch_btn">
-    <%= link_to product_registration_path(current_user), target: "_blank" do %>
-      <img src= "https://i2.wp.com/sozaikoujou.com/wordpress/wp-content/uploads/2015/12/th_business_icone_simple_home.png?w=600&ssl=1"  border="0", class="reserch_btn_btn" />
-    <% end %>
-    <div class="box25">
-      <p class="reserch_p">商品登録ページへ️️️</p>
-    </div>
-  </div>
-<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,4 +20,15 @@
     </div>
     <%= debug(params) if Rails.env.development? %>
   </body>
+
+  <% if logged_in? && current_user.admin? %>
+    <div class="reserch_btn">
+      <%= link_to product_registration_path(current_user), target: "_blank" do %>
+        <img src= "https://i2.wp.com/sozaikoujou.com/wordpress/wp-content/uploads/2015/12/th_business_icone_simple_home.png?w=600&ssl=1"  border="0", class="reserch_btn_btn" />
+      <% end %>
+      <div class="box25">
+        <p class="reserch_p">商品登録ページへ️️️</p>
+      </div>
+    </div>
+  <% end %>
 </html>


### PR DESCRIPTION
・常時ページ右下表示から、ページの最下層に表示されるように修正
・該当コードは、header.html.erbからappllication.html.erbに移動しています。